### PR TITLE
Add numword and navword

### DIFF
--- a/config/custom/behaviors.dtsi
+++ b/config/custom/behaviors.dtsi
@@ -18,5 +18,12 @@
             #binding-cells = <1>;
             continue-list = <LCLK RCLK MCLK MB4 MB5 MOVE_LEFT MOVE_DOWN MOVE_UP MOVE_RIGHT SCRL_LEFT SCRL_DOWN SCRL_UP SCRL_RIGHT>;
         };
+
+        nav_word: nav_word {
+            compatible = "zmk, behavior-auto-layer";
+            #binding-cells = <1>;
+            continue-list = <UP DOWN LEFT RIGHT PG_UP PG_DN>;
+            ignore-modifiers;
+        }
     };
 };

--- a/config/custom/behaviors.dtsi
+++ b/config/custom/behaviors.dtsi
@@ -20,7 +20,7 @@
         };
 
         nav_word: nav_word {
-            compatible = "zmk, behavior-auto-layer";
+            compatible = "zmk,behavior-auto-layer";
             #binding-cells = <1>;
             continue-list = <UP DOWN LEFT RIGHT PG_UP PG_DN>;
             ignore-modifiers;

--- a/config/custom/behaviors.dtsi
+++ b/config/custom/behaviors.dtsi
@@ -24,6 +24,6 @@
             #binding-cells = <1>;
             continue-list = <UP DOWN LEFT RIGHT PG_UP PG_DN>;
             ignore-modifiers;
-        }
+        };
     };
 };

--- a/config/custom/combos.dtsi
+++ b/config/custom/combos.dtsi
@@ -18,8 +18,8 @@
 
         SLOW(combo_hub_mode, 28 41, &to HUB) // f + b -> hub layer
         SLOW(combo_mouse_mode, 29 30, &smart_mouse MSE) // g + h -> mouse layer
-        SLOW(combo_numword, 17 29, &num_word NUM) // t + g -> num word
-        SLOW(combo_navword, 16 28, &nav_word NAV) // r + f -> nav word
+        SLOW(combo_numword, 17 29, &num_word NUM) // d + f -> num word
+        SLOW(combo_navword, 26 27, &nav_word NAV) // s + d -> nav word
 
         FAST(combo_esc, 14 15, &kp ESC) // w + e -> esc
         FAST(combo_tab, 15 16, &kp TAB) // e + r -> tab

--- a/config/custom/combos.dtsi
+++ b/config/custom/combos.dtsi
@@ -18,7 +18,7 @@
 
         SLOW(combo_hub_mode, 28 41, &to HUB) // f + b -> hub layer
         SLOW(combo_mouse_mode, 29 30, &smart_mouse MSE) // g + h -> mouse layer
-        SLOW(combo_numword, 17 29, &num_word NUM) // d + f -> num word
+        SLOW(combo_numword, 27 28, &num_word NUM) // d + f -> num word
         SLOW(combo_navword, 26 27, &nav_word NAV) // s + d -> nav word
 
         FAST(combo_esc, 14 15, &kp ESC) // w + e -> esc

--- a/config/custom/combos.dtsi
+++ b/config/custom/combos.dtsi
@@ -19,6 +19,7 @@
         SLOW(combo_hub_mode, 28 41, &to HUB) // f + b -> hub layer
         SLOW(combo_mouse_mode, 29 30, &smart_mouse MSE) // g + h -> mouse layer
         SLOW(combo_numword, 17 29, &num_word NUM) // t + g -> num word
+        SLOW(combo_navword, 16 28, &nav_word NAV) // r + f -> nav word
 
         FAST(combo_esc, 14 15, &kp ESC) // w + e -> esc
         FAST(combo_tab, 15 16, &kp TAB) // e + r -> tab
@@ -29,6 +30,6 @@
         FAST(combo_app, 46 47, &kp K_APP) // , + . -> application (context menu)
         FAST(combo_mute, 39 40, &kp F23) // c + v -> F23
         FAST(combo_deafen, 40 41, &kp F24) // v + b -> F24
-        FAST(combo_nav_mode, 38 39, &tog NAV) // x + c -> nav layer
+        FAST(combo_cancel, 38 39, &kp K_CANCEL) // x + c -> cancel (to escape from sticky layers)
     };
 };

--- a/config/layers/sofle/base.dtsi
+++ b/config/layers/sofle/base.dtsi
@@ -8,7 +8,7 @@
 &kp ESC        &kp N1         &kp N2        &kp N3        &kp N4         &kp N5                                    &kp N6       &kp N7         &kp N8        &kp N9        &kp N0            &kp BSPC
 &kp GRAVE      &kp Q          &kp W         &kp E         &kp R          &kp T                                     &kp Y        &kp U          &kp I         &kp O         &kp P             &kp LBKT
 &kp TAB        &hmls LGUI A   &hmls LALT S  &hmlf LCTRL D &hmlf LSHFT F  &kp G                                     &lt NAV H    &hmrf RSHFT J  &hmrf RCTRL K &hmrs RALT L  &hmrs RGUI SEMI   &kp SQT
-&sk LSHFT      &kp Z          &kp X         &kp C         &kp V          &kp B        &kp F24        &kp C_MUTE    &lt NUM N    &kp M          &kp COMMA     &kp DOT       &kp FSLH          &sk RSHFT 
+&sk LSHFT      &kp Z          &kp X         &kp C         &kp V          &lt NUM B    &kp F24        &kp C_MUTE    &lt NUM N    &kp M          &kp COMMA     &kp DOT       &kp FSLH          &sk RSHFT 
                               &kp LGUI      &kp LALT      &kp LCTRL      &kp SPACE    &lt FN TAB     &kp RET       &kp BSPC     &kp BSLH       &kp MINUS     &kp DEL  
             >;
 

--- a/config/layers/sofle/base.dtsi
+++ b/config/layers/sofle/base.dtsi
@@ -9,7 +9,7 @@
 &kp GRAVE      &kp Q          &kp W         &kp E         &kp R          &kp T                                     &kp Y        &kp U          &kp I         &kp O         &kp P             &kp LBKT
 &kp TAB        &hmls LGUI A   &hmls LALT S  &hmlf LCTRL D &hmlf LSHFT F  &kp G                                     &lt NAV H    &hmrf RSHFT J  &hmrf RCTRL K &hmrs RALT L  &hmrs RGUI SEMI   &kp SQT
 &sk LSHFT      &kp Z          &kp X         &kp C         &kp V          &kp B        &kp F24        &kp C_MUTE    &lt NUM N    &kp M          &kp COMMA     &kp DOT       &kp FSLH          &sk RSHFT 
-                              &kp LGUI      &kp LALT      &kp LCTRL      &kp SPACE    &lt FN TAB     &lt NUM RET   &lt NAV BSPC &kp BSLH       &kp MINUS     &kp DEL  
+                              &kp LGUI      &kp LALT      &kp LCTRL      &kp SPACE    &lt FN TAB     &kp RET       &kp BSPC     &kp BSLH       &kp MINUS     &kp DEL  
             >;
 
             sensor-bindings = <&inc_dec_kp F13 F14 &inc_dec_kp F15 F16>;

--- a/config/layers/sofle/nav.dtsi
+++ b/config/layers/sofle/nav.dtsi
@@ -9,7 +9,7 @@
 &trans         &kp PG_UP      &kp HOME        &kp UP         &kp END         &kp PG_DN                                  &none           &kp C_PREV      &kp C_PP      &kp C_NEXT      &none             &trans
 &trans         &kp DEL        &kp LEFT        &kp DOWN       &kp RIGHT       &kp INS                                    &none           &kp RSHFT       &kp RCTRL     &kp RALT        &kp RGUI          &trans
 &trans         &kp PSCRN      &kp PAUSE_BREAK &key_repeat    &caps_word      &none         &trans         &trans        &kp LEFT        &kp DOWN        &kp UP        &kp RIGHT       &none             &trans
-                              &trans          &trans         &trans          &kp SPACE     &kp TAB        &kp RET       &kp BSPC        &trans          &trans        &trans 
+                              &trans          &trans         &trans          &trans        &trans         &trans        &trans          &trans          &trans        &trans 
             >;
 
             sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP &rot_scrl>;

--- a/config/layers/sofle/num.dtsi
+++ b/config/layers/sofle/num.dtsi
@@ -5,11 +5,11 @@
         num {
             display-name = "num";
             bindings = <
-&trans         &trans          &trans          &trans        &trans          &trans                                       &trans          &trans          &trans        &trans          &trans            &trans
-&trans         &kp N1          &kp N2          &kp N3        &kp N4          &kp N5                                       &trans          &trans          &trans        &trans          &trans            &trans
-&trans         &kp N6          &kp N7          &kp N8        &kp N9          &kp N0                                       &trans          &kp RSHFT       &kp RCTRL     &kp RALT        &kp RGUI          &trans
-&trans         &kp KP_SLASH    &kp KP_ASTERISK &kp KP_MINUS  &kp KP_PLUS     &kp KP_DOT         &none        &none        &trans          &trans          &trans        &trans          &trans            &trans
-                               &trans          &trans        &trans          &kp SPACE          &kp EQUAL    &kp RET      &kp BSPC        &trans          &trans        &trans
+&trans         &trans          &trans          &trans         &trans          &trans                                       &trans          &trans          &trans        &trans          &trans            &trans
+&trans         &trans          &trans          &trans         &trans          &kp EQUAL                                    &kp KP_PLUS     &kp KP_ASTERISK &trans        &trans          &trans            &trans
+&trans         &hmls LGUI N1   &hmls LALT N2   &hmlf LCTRL N3 &hmlf LSHFT N4  &kp N5                                       &kp N6          &hmrf RSHFT N7  &hmrf RCTRL N8 &hmrs RALT N9  &hmrs RGUI N0     &trans
+&trans         &trans          &trans          &trans         &trans          &kp KP_DOT         &none        &none        &kp KP_MINUS    &kp KP_SLASH    &trans        &trans          &trans            &trans
+                               &trans          &trans         &trans          &trans             &trans       &trans       &trans          &trans          &trans        &trans
             >;
 
             sensor-bindings = <&inc_dec_kp LC(Z) LC(Y) &rot_scrl>;

--- a/config/west.yml
+++ b/config/west.yml
@@ -9,10 +9,10 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3.0
       import: app/west.yml      
     - name: zmk-auto-layer
       remote: urob
-      revision: main
+      revision: v0.3.0
   self:
     path: config

--- a/config/west.yml
+++ b/config/west.yml
@@ -9,10 +9,10 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: v0.3.0
+      revision: main
       import: app/west.yml      
     - name: zmk-auto-layer
       remote: urob
-      revision: v0.3.0
+      revision: next
   self:
     path: config


### PR DESCRIPTION
Numword (d+f) enables sticky num layer, which will be disabled if CANCEL key (x + c combo) or key not defined on a layer is pressed.
Navword (s+d) does the same, but with the nav layer

To reduce strain on thumbs, nav and num layer toggles were moved near home row keys
Also, again, I changed num layers to make it into a line. This makes it easier to memorise, and at the same time, places it on a home row, also decreasing the finger travel.